### PR TITLE
Prevent overwrite of nonces and partial signatures and verify partial signatures

### DIFF
--- a/src/Deposit.hs
+++ b/src/Deposit.hs
@@ -281,8 +281,7 @@ processGraphGenerated state _ _ = (state, Nothing) -- do nothing if the state ha
 processNonce deposit@GraphGenerated {..} cfg nonce operatorIdx =
   case Map.lookup operatorIdx pubnonces of
     Just _ ->
-      -- Ignore incoming Nonce if the operator's Nonce has already been received
-      (deposit, Nothing)
+      error $ "Duplicate nonce received from operator: " ++ show operatorIdx
     Nothing ->
       let newNonces = Map.insert operatorIdx nonce pubnonces
           (newState, duty) =
@@ -312,8 +311,7 @@ processNonce _ _ _ _ = error "Invalid state transition"
 processPartial deposit@DepositNoncesCollected {..} cfg partialSig operatorIdx =
   case Map.lookup operatorIdx partialSignatures of
     Just _ ->
-      -- Ignore incoming PartialSignature if some PartialSignature from the same operator has been received before
-      (deposit, Nothing)
+      error $ "Duplicate partial signature received from operator: " ++ show operatorIdx
     Nothing ->
       let operatorNonce = case Map.lookup operatorIdx pubnonces of
             Just nonce -> nonce
@@ -405,8 +403,7 @@ processFulfillment _ _ _ _ = error "Invalid state transition"
 processPayoutNonce deposit@Fulfilled {..} cfg nonce operatorIdx =
   case Map.lookup operatorIdx payoutNonces of
     Just _ ->
-      -- Ignore incoming Nonce if the operator's Nonce has already been received
-      (deposit, Nothing)
+      error $ "Duplicate payout nonce received from operator: " ++ show operatorIdx
     Nothing ->
       let newPayoutNonces = Map.insert operatorIdx nonce payoutNonces
           (newState, duty) =
@@ -433,8 +430,7 @@ processPayoutNonce _ _ _ _ = error "Invalid state transition"
 processPayoutPartial deposit@PayoutNoncesCollected {..} cfg partialSig operatorIdx =
   case Map.lookup operatorIdx payoutPartialSignatures of
     Just _ ->
-      -- Ignore incoming PartialSignature if some PartialSignature fromt the same operator has been received before
-      (deposit, Nothing)
+      error $ "Duplicate payout partial signature received from operator: " ++ show operatorIdx
     Nothing ->
       let operatorNonce = case Map.lookup operatorIdx payoutNonces of
             Just nonce -> nonce

--- a/src/Graph.hs
+++ b/src/Graph.hs
@@ -469,7 +469,7 @@ processNonces AdaptorsVerified {..} execConfig (opIdx, receivedNonces) =
   let newNonces =
         if isNothing (Map.lookup opIdx nonces)
           then Map.insert opIdx receivedNonces nonces
-          else nonces -- ignore duplicate nonces from same operator
+          else error $ "Duplicate nonces received from operator: " ++ show opIdx
       expectedOperatorCount = opCardinality execConfig
   in  if Map.size newNonces == expectedOperatorCount
         then
@@ -513,7 +513,7 @@ processPartials NoncesCollected {..} execConfig (opIdx, receivedPartials) =
             if verifyAllPartials execConfig opIdx operatorNonces aggNonces sighashes' receivedPartials
               then Map.insert opIdx receivedPartials partials
               else error $ "Partial Signature Verification Failed for Operator: " ++ show opIdx
-          else partials -- ignore duplicate partials from same operator
+          else error $ "Duplicate partial signatures received from operator: " ++ show opIdx
       expectedOperatorCount = opCardinality execConfig
   in  if Map.size newPartials == expectedOperatorCount
         then

--- a/src/Stake.hs
+++ b/src/Stake.hs
@@ -185,7 +185,7 @@ processUnstakingNonces StakeGraphGenerated {..} opTable operatorIdx' pubNonces =
   let updatedNonces =
         if isNothing $ Map.lookup operatorIdx' nonces
           then Map.insert operatorIdx' pubNonces nonces
-          else nonces -- Ignore duplicate nonces from the same operator
+          else error $ "Duplicate unstaking nonces received from operator: " ++ show operatorIdx'
   in  if Map.size updatedNonces == opCardinality opTable
         then
           let aggNonces = "agg_nonce_placeholder" :| [] -- In a real implementation, this would be computed from the collected nonces
@@ -209,7 +209,7 @@ processUnstakingPartials UnstakingNoncesCollected {..} opTable operatorIdx' part
             if verifyAllPartials opTable operatorIdx' operatorNonces aggNonces partialSig
               then Map.insert operatorIdx' partialSig partials
               else error $ "Partial Signature Verification Failed for Operator: " ++ show operatorIdx'
-          else partials -- Ignore duplicate partial signatures from the same operator
+          else error $ "Duplicate unstaking partial signatures received from operator: " ++ show operatorIdx'
   in  if Map.size updatedPartials == opCardinality opTable
         then
           let signatures = "signature_placeholder" :| [] -- In a real implementation, this would be computed from the collected partial signatures and agg nonce


### PR DESCRIPTION
The state machine shouldn't entertain different nonces or partial signatures from the same operator. 
The partial signature should also be verified before it is accepted and inserted into the map.