### PR TITLE
Fix: Remove the PayoutPartialsCollected State

### DIFF
--- a/src/Deposit.hs
+++ b/src/Deposit.hs
@@ -196,7 +196,9 @@ data DepositDuty
       , depositIdx :: DepositIdx
       , aggNonce :: AggNonce
       }
-  | PublishPayout -- publish the cooperative payout transaction to the Bitcoin network
+  | -- The assignee generates their own partial signature as well as signing and broadcasting the payout tx.
+    -- The extra fields (aggNonce, collectedPartials) are needed for generating the assignee's partial.
+    PublishPayout
       { depositOutPoint :: OutPoint
       , depositIdx :: DepositIdx
       , aggNonce :: AggNonce
@@ -427,6 +429,14 @@ processPayoutNonce deposit@PayoutDescriptorReceived {..} cfg nonce operatorIdx =
                         , ..
                         }
                     duty' =
+                      -- Everyone except the assignee publishes their cooperative-payout partial signature.
+                      -- Rationale: prevent payout-tx hostage attacks.
+                      -- If the assignee also published their partial, a malicious coordinator/operator could
+                      -- withhold their own partial and force the assignee to fall back to posting a claim.
+                      -- If a cooperative payout is later broadcast, the assignee is unable to spend the
+                      -- contested or uncontested path, and can be slashed after the timelock expires.
+                      -- By withholding the assignee's partial, only the assignee can finalize and broadcast
+                      -- the cooperative payout transaction.
                       if assignee /= povIdx cfg
                         then Just PublishPayoutPartial {..}
                         else Nothing


### PR DESCRIPTION
In the current design, the partial signatures for the cooperative payout are broadcasted by every operator including the assignee. This opens up an attack vector where an operator can withhold their partial while gaining access to partials from all other operators. Once the cooperative path fails and the assignee posts the claim, the faulty operator can post the cooperative payout transaction. This ensures that neither the contested nor the uncontested payout can be spent and after the timeout, the assignee's stake can be slashed.

To prevent this, we ensure that the assignee never publishes their partial signature on the cooperative payout transaction to their peers. From the `PayoutNoncesCollected` state, everyone except the assignee will send the partial signatures for the cooperative payout. Once partials from everyone except the assignee are received, the assignee's node will dispatch the duty to post the cooperative payout transaction. This duty will generate their partial signature as a substep and this partial signature will never be stored in the state. In this design, `PayoutPartialsReceived` state is not reachable and can be removed.