### PR TITLE
fix(gsm): process payout when in Contested state

### DIFF
--- a/src/Graph.hs
+++ b/src/Graph.hs
@@ -956,6 +956,9 @@ mkWithdrawn depositIdx operatorIdx payoutTx =
 processPayout Claimed {..} tx
   | txid tx == uncontestedPayout graphSummary = mkWithdrawn depositIdx operatorIdx tx
   | otherwise = error "Invalid uncontested payout transaction"
+processPayout Contested {..} tx
+  | txid tx == contestedPayout graphSummary = mkWithdrawn depositIdx operatorIdx tx
+  | otherwise = error "Invalid contested payout transaction"
 processPayout BridgeProofPosted {..} tx
   | txid tx == contestedPayout graphSummary = mkWithdrawn depositIdx operatorIdx tx
   | otherwise = error "Invalid contested payout transaction"


### PR DESCRIPTION
In the “contested” state, the bridge state machine needs to watch the blockchain for confirmations of the “contested payout” transaction.