### PR TITLE
feat(gsm): support bridge proof posted after counterproof

### DIFF
--- a/src/Graph.hs
+++ b/src/Graph.hs
@@ -796,6 +796,18 @@ processBridgeProofTimeout Contested {..} tx
       , emptyOutput
       )
   | otherwise = error "Invalid bridge proof timeout transaction"
+processBridgeProofTimeout CounterProofPosted {..} tx
+  | txid tx == bridgeProofTimeout graphSummary && isNothing refutedProof -- proof has to be Nothing for the timeout to be posted but adding check for safety
+    =
+      ( BridgeProofTimedout
+          { expectedSlashTxid = slash graphSummary
+          , signedSlashTx = "slash_tx_placeholder" -- Placeholder for signed slash transaction
+          , claimTxid = claim graphSummary
+          , ..
+          }
+      , emptyOutput
+      )
+  | otherwise = error "Invalid bridge proof timeout transaction"
 processBridgeProofTimeout BridgeProofTimedout {} _ = error "Bridge proof timeout already processed"
 processBridgeProofTimeout state _ = error $ "Invalid state for bridge proof timeout: " ++ show state
 

--- a/src/Graph.hs
+++ b/src/Graph.hs
@@ -764,23 +764,14 @@ processBridgeProof Contested {..} opTable tx bridgeProofBlockHeight
           )
   | otherwise = error "Invalid bridge proof transaction"
 processBridgeProof BridgeProofPosted {} _ _ _ = error "Bridge proof already posted"
-processBridgeProof
-  CounterProofPosted
-    { depositIdx = _depositIdx
-    , operatorIdx = _operatorIdx
-    , depositOutPoint = _depositOutPoint
-    , blockHeight = _blockHeight
-    , graphData = _graphData
-    , graphSummary = _graphSummary
-    , contestBlockHeight = _contestBlockHeight
-    , refutedProof = _refutedProof
-    , counterProofsAndConfs = _counterProofsAndConfs
-    , counterProofNacks = _counterProofNacks
-    , counterProofLabels = _counterProofLabels
-    }
-  _
-  _
-  _ = error "TODO"
+processBridgeProof CounterProofPosted {refutedProof, ..} _ _ _
+  | isNothing refutedProof =
+      let proof = "proof_placeholder" -- Placeholder for proof (needs to be extracted from tx)
+          counterProofTx = "counterproof_tx_placeholder" -- Placeholder for counterproof transaction
+      in  ( CounterProofPosted {refutedProof = Just proof, ..}
+          , GraphTransitionOutput {signal = Nothing, duty = Just PublishCounterProof {counterProofTx, ..}}
+          )
+  | otherwise = error "Bridge proof already posted"
 processBridgeProof state _ _ _ = error $ "Invalid state for bridge proof: " ++ show state
 
 processBridgeProofTimeout Contested {..} tx

--- a/src/Graph.hs
+++ b/src/Graph.hs
@@ -291,6 +291,7 @@ data GraphState
       , graphData :: GraphData
       , graphSummary :: GraphSummary
       , contestBlockHeight :: BitcoinBlockHeight
+      , refutedProof :: Maybe Proof -- the proof (data) being refuted
       , counterProofsAndConfs :: Map.Map OperatorIdx (Txid, BitcoinBlockHeight) -- the txids of the counterproof transactions submitted on chain along with their confirmation heights
       , counterProofNacks :: Map.Map OperatorIdx Txid -- the txids of the counterproof NACK transactions submitted on chain
       , counterProofLabels :: Map.Map OperatorIdx (NonEmpty Labels) -- the labels (GC labels) committed in the counterproofs
@@ -614,7 +615,7 @@ processAssignment GraphSigned {..} assignee deadline recipientDesc
           ++ " but this graph belongs to operator "
           ++ show operatorIdx
 -- reassignment
-processAssignment state@Assigned {..} newAssignee newDeadline newRecipientDesc
+processAssignment Assigned {..} newAssignee newDeadline newRecipientDesc
   -- recipient descriptor cannot be changed once assigned
   | recipientDesc /= newRecipientDesc =
       error "Recipient descriptor cannot be changed for an existing assignment"
@@ -763,6 +764,23 @@ processBridgeProof Contested {..} opTable tx bridgeProofBlockHeight
           )
   | otherwise = error "Invalid bridge proof transaction"
 processBridgeProof BridgeProofPosted {} _ _ _ = error "Bridge proof already posted"
+processBridgeProof
+  CounterProofPosted
+    { depositIdx = _depositIdx
+    , operatorIdx = _operatorIdx
+    , depositOutPoint = _depositOutPoint
+    , blockHeight = _blockHeight
+    , graphData = _graphData
+    , graphSummary = _graphSummary
+    , contestBlockHeight = _contestBlockHeight
+    , refutedProof = _refutedProof
+    , counterProofsAndConfs = _counterProofsAndConfs
+    , counterProofNacks = _counterProofNacks
+    , counterProofLabels = _counterProofLabels
+    }
+  _
+  _
+  _ = error "TODO"
 processBridgeProof state _ _ _ = error $ "Invalid state for bridge proof: " ++ show state
 
 processBridgeProofTimeout Contested {..} tx
@@ -802,6 +820,7 @@ processCounterProof Contested {..} opTable tx counterproofBlockHeight =
               { counterProofsAndConfs = newCounterProofs
               , counterProofNacks = mempty
               , counterProofLabels = newCounterProofLabels
+              , refutedProof = Nothing -- someone posted a counterproof _before_ the bridge proof
               , ..
               }
           , GraphTransitionOutput
@@ -833,6 +852,7 @@ processCounterProof BridgeProofPosted {..} opTable tx counterproofBlockHeight =
               { counterProofsAndConfs = newCounterProofs
               , counterProofNacks = mempty
               , counterProofLabels = newCounterProofLabels
+              , refutedProof = Just proof -- the counterproof is refuting this bridge proof
               , ..
               }
           , GraphTransitionOutput

--- a/src/Graph.hs
+++ b/src/Graph.hs
@@ -1209,7 +1209,7 @@ processRetryTick state opTable = case state of
             , proof = proof
             }
     | otherwise -> Set.empty
-  CounterProofPosted {..}
+  CounterProofPosted {refutedProof, ..}
     | operatorIdx == povIdx opTable ->
         let postedCounterProofNacks = Map.keysSet counterProofNacks
             expectedCounterProofNacks = Map.keysSet $ counterproofs graphSummary
@@ -1224,6 +1224,13 @@ processRetryTick state opTable = case state of
                     }
               )
               missingNacks
+    | operatorIdx == povIdx opTable && isNothing refutedProof ->
+        Set.singleton PublishBridgeProof {depositIdx, operatorIdx, bridgeProofTx = "bridge_proof_tx_placeholder"} -- Placeholder for bridge proof transaction generation and finalization
+    | operatorIdx /= povIdx opTable -- not my graph
+        && isJust refutedProof -- proof exists
+        && not (verify $ fromJust refutedProof) -- existing proof is invalid
+        && povIdx opTable `elem` Map.keys counterProofsAndConfs -> -- haven't posted the counterproof yet
+        Set.singleton PublishCounterProof {counterProofTx = "counterproof_tx_placeholder", proof = fromJust refutedProof, ..}
     | otherwise -> Set.empty
   -- the rest of the duties need not be retried
   _ -> Set.empty

--- a/src/Graph.hs
+++ b/src/Graph.hs
@@ -72,6 +72,9 @@ txid _ = "txid_placeholder" -- Placeholder implementation
 inpoints :: Transaction -> NonEmpty OutPoint
 inpoints _ = ("txid_placeholder", 0) :| [] -- Placeholder implementation for input outpoints (head :| tail)
 
+verify :: Proof -> Bool
+verify _ = True -- Placeholder implementation for proof verification (accept all proofs for now)
+
 -- Parameters
 -- NOTE: numbers are arbitrary and expressed in terms of bitcoin blocks
 -- payoutTimeout >> all other timeouts
@@ -750,7 +753,7 @@ processBridgeProof Contested {..} opTable tx bridgeProofBlockHeight
           , GraphTransitionOutput
               { signal = Nothing
               , duty =
-                  if operatorIdx /= povIdx opTable
+                  if operatorIdx /= povIdx opTable && not (verify proof)
                     then
                       Just
                         PublishCounterProof
@@ -764,12 +767,18 @@ processBridgeProof Contested {..} opTable tx bridgeProofBlockHeight
           )
   | otherwise = error "Invalid bridge proof transaction"
 processBridgeProof BridgeProofPosted {} _ _ _ = error "Bridge proof already posted"
-processBridgeProof CounterProofPosted {refutedProof, ..} _ _ _
+processBridgeProof CounterProofPosted {refutedProof, ..} opTable _ _
   | isNothing refutedProof =
       let proof = "proof_placeholder" -- Placeholder for proof (needs to be extracted from tx)
           counterProofTx = "counterproof_tx_placeholder" -- Placeholder for counterproof transaction
       in  ( CounterProofPosted {refutedProof = Just proof, ..}
-          , GraphTransitionOutput {signal = Nothing, duty = Just PublishCounterProof {counterProofTx, ..}}
+          , GraphTransitionOutput
+              { signal = Nothing
+              , duty =
+                  if povIdx opTable /= operatorIdx && not (verify proof)
+                    then Just PublishCounterProof {counterProofTx, ..}
+                    else Nothing
+              }
           )
   | otherwise = error "Bridge proof already posted"
 processBridgeProof state _ _ _ = error $ "Invalid state for bridge proof: " ++ show state

--- a/src/Graph.hs
+++ b/src/Graph.hs
@@ -269,6 +269,7 @@ data GraphState
       , blockHeight :: BitcoinBlockHeight
       , graphData :: GraphData
       , graphSummary :: GraphSummary
+      , fulfillmentTxid' :: Maybe Txid -- needed to know whether a claim is valid in the subsequent states where proof may not be present.
       , contestBlockHeight :: BitcoinBlockHeight -- needed in case the operator needs to be slashed after contested payout timeout
       , bridgeProofTxid :: Txid -- the txid of the bridge proof transaction submitted on chain
       , bridgeProofBlockHeight :: BitcoinBlockHeight -- the block height at which the bridge proof transaction was confirmed
@@ -294,6 +295,7 @@ data GraphState
       , graphData :: GraphData
       , graphSummary :: GraphSummary
       , contestBlockHeight :: BitcoinBlockHeight
+      , fulfillmentTxid' :: Maybe Txid -- needed to know whether a claim is valid in the absence of a bridge proof.
       , refutedProof :: Maybe Proof -- the proof (data) being refuted
       , counterProofsAndConfs :: Map.Map OperatorIdx (Txid, BitcoinBlockHeight) -- the txids of the counterproof transactions submitted on chain along with their confirmation heights
       , counterProofNacks :: Map.Map OperatorIdx Txid -- the txids of the counterproof NACK transactions submitted on chain
@@ -1039,7 +1041,17 @@ notifyNewBlock curState@Contested {..} _opTable newBlockHeight
       )
   | otherwise = (curState {blockHeight = newBlockHeight}, emptyOutput)
 -- check if ACK is possible
-notifyNewBlock curState@CounterProofPosted {..} opTable newBlockHeight
+notifyNewBlock curState@CounterProofPosted {refutedProof, fulfillmentTxid', ..} opTable newBlockHeight
+  | isNothing refutedProof && newBlockHeight > contestBlockHeight + proofTimeout =
+      ( curState {blockHeight = newBlockHeight}
+      , GraphTransitionOutput
+          { signal = Nothing
+          , duty =
+              if povIdx opTable /= operatorIdx && isNothing fulfillmentTxid'
+                then Just PublishBridgeProofTimeout {signedTimeoutTx = "bridge_proof_timeout_tx_placeholder"}
+                else Nothing
+          }
+      )
   | newBlockHeight > contestBlockHeight + payoutTimeout =
       (curState {blockHeight = newBlockHeight}, mkSlashOutput curState) -- Placeholder for slash transaction
       -- if no one ACK's their counterproof, the operator could still get a payout (even without NACK-ing)


### PR DESCRIPTION
This PR adds support for the case where a counterproof is posted _before_ a bridge proof. This can present issues in two ways:

- If the assignee node crashes before the proof has been posted on chain but _after_ observing the counterproof transaction.

  Then, the assignee node will not produce a duty to publish the proof again. This allows a watchtower to post the bridge proof timeout transaction and slash the operator even if they may have fulfilled the withdrawal correctly. The fix is to allow the SM to transition from the `Contested` to the `CounterproofPosted` state directly but adding a field for the `refutedProof` which may not exist. If the proof does not exist, the retry handler will publish a duty to produce the proof.
  
- If the assignee and the watchtower are colluding, and the assignee never posts the bridge proof.

  In this case, the rest of the honest watchtowers, do not publish a counterproof (because there is no proof to refute). They don't publish the bridge proof timeout transaction either because they are in the `CounterproofPosted` state. This allows the operator to wait out the ACK timelock and then, get the contested payout. The fix is to produce a duty to publish the bridge proof timeout transaction if the `refutedProof` field does not contain the proof in the `CounterproofPosted` state _and_ if the claim is invalid.

SM Diagrams will be updated after this PR is approved.

AI was not used.