### PR TITLE
fix(gsm): negate the check on counterproofs posted to make it valid

### DIFF
--- a/src/Graph.hs
+++ b/src/Graph.hs
@@ -1256,7 +1256,7 @@ processRetryTick state opTable = case state of
     | operatorIdx /= povIdx opTable -- not my graph
         && isJust refutedProof -- proof exists
         && not (verify $ fromJust refutedProof) -- existing proof is invalid
-        && povIdx opTable `elem` Map.keys counterProofsAndConfs -> -- haven't posted the counterproof yet
+        && povIdx opTable `notElem` Map.keys counterProofsAndConfs -> -- haven't posted the counterproof yet
         Set.singleton PublishCounterProof {counterProofTx = "counterproof_tx_placeholder", proof = fromJust refutedProof, ..}
     | otherwise -> Set.empty
   -- the rest of the duties need not be retried


### PR DESCRIPTION
One of the checks needed when we decide on publishing `CounterProof` when `retryTick` happens in the `CounterProofPublished` state is that the POV operator should not have `Counterproof` onchain. 

This was captured in the comments but a negation was missing in the Haskell code. This one word PR fixes that.