### PR TITLE
feat(ssm): track stake slashing

### DIFF
--- a/src/Stake.hs
+++ b/src/Stake.hs
@@ -15,6 +15,7 @@ module Stake
   , notifyNewBlock
   , hasStaked
   , isUnstaked
+  , isSlashed
   , getPreimage
   , lastProcessedBlock
   , processNagTick
@@ -419,8 +420,13 @@ isUnstaked _ = False
 -- this is not information that will change over time, so it is not emitted as a signal in response to events
 getPreimage :: StakeState -> Maybe Preimage
 getPreimage PreimageRevealed {..} = Just preimage
+getPreimage Slashed {preimage' = Just preimage} = Just preimage
 getPreimage Unstaked {..} = Just preimage
 getPreimage _ = Nothing
+
+isSlashed :: StakeState -> Bool
+isSlashed Slashed {} = True
+isSlashed _ = False
 
 lastProcessedBlock :: StakeState -> Maybe BitcoinBlockHeight
 lastProcessedBlock state = case state of

--- a/src/Stake.hs
+++ b/src/Stake.hs
@@ -32,7 +32,6 @@ type U32 = Word32
 type OperatorIdx = U32
 type BitcoinBlockHeight = U32
 type StakeData = String -- Placeholder for actual stake inputs (required to generate the entire staking/unstaking graph)
-type StakeGraphSummary = String -- Placeholder for graph summary (e.g. stake graph txids)
 type StakeFunctor a = NonEmpty a -- Placeholder for per-transaction graph data
 type Preimage = [Word8] -- Placeholder for actual preimage data
 type Txid = String -- Placeholder for actual transaction ID
@@ -44,20 +43,23 @@ type Signature = String -- Placeholder for aggregated signature
 type SchnorrKey = String -- Placeholder for Schnorr public key
 type P2PKey = String -- Placeholder for P2P public key
 
+data StakeGraphSummary = StakeGraphSummary
+  { stake :: Txid
+  , unstakingIntent :: Txid
+  , unstaking :: Txid
+  }
+  deriving (Show, Eq, Ord)
+
 txid :: Transaction -> Txid
 txid _ = "txid_placeholder" -- Placeholder implementation
 
 stakeGraphSummaryFromStakeData :: StakeData -> StakeGraphSummary
-stakeGraphSummaryFromStakeData _ = "stake_graph_summary_placeholder" -- Placeholder implementation
-
-expectedStakeTxidFromSummary :: StakeGraphSummary -> Txid
-expectedStakeTxidFromSummary _ = "expected_stake_txid_placeholder" -- Placeholder implementation
-
-expectedUnstakingTxidFromSummary :: StakeGraphSummary -> Txid
-expectedUnstakingTxidFromSummary _ = "expected_unstaking_txid_placeholder" -- Placeholder implementation
-
-expectedUnstakingIntentTxidFromSummary :: StakeGraphSummary -> Txid
-expectedUnstakingIntentTxidFromSummary _ = "expected_unstaking_intent_txid_placeholder" -- Placeholder implementation
+stakeGraphSummaryFromStakeData _ =
+  StakeGraphSummary
+    { stake = "stake_txid_placeholder"
+    , unstakingIntent = "unstaking_intent_txid_placeholder"
+    , unstaking = "unstaking_txid_placeholder"
+    } -- Placeholder implementation
 
 -- Parameters
 -- Numbers are chosen arbitrarily
@@ -284,7 +286,7 @@ processUnstakingPartials UnstakingSigned {} _ _ _ = error "Duplicate: Unstaking 
 processUnstakingPartials state _ _ _ = error $ "Rejected: Invalid state for collecting unstaking partials: " ++ show state
 
 processStakeConfirmed UnstakingSigned {..} tx
-  | txid tx == expectedStakeTxidFromSummary summary =
+  | txid tx == stake summary =
       let newState =
             Confirmed
               { operatorIdx = operatorIdx
@@ -297,7 +299,7 @@ processStakeConfirmed UnstakingSigned {..} tx
       in  (newState, output)
   | otherwise = error "Rejected: Unexpected transaction for stake confirmation"
 processStakeConfirmed UnstakingNoncesCollected {..} tx
-  | txid tx == expectedStakeTxidFromSummary summary =
+  | txid tx == stake summary =
       let newState =
             Confirmed
               { operatorIdx = operatorIdx
@@ -313,7 +315,7 @@ processStakeConfirmed Confirmed {} _ = error "Duplicate: Stake has already been 
 processStakeConfirmed state _ = error $ "Rejected: Invalid state for stake confirmation: " ++ show state
 
 processPreimageRevealed Confirmed {..} tx btcBlockHeight
-  | txid tx /= expectedUnstakingIntentTxidFromSummary summary =
+  | txid tx /= unstakingIntent summary =
       error "Rejected: Transaction does not match expected unstaking intent transaction"
   | otherwise =
       let revealedPreimage = replicate 32 0 -- Placeholder for extracting the first witness stack item preimage
@@ -324,7 +326,7 @@ processPreimageRevealed Confirmed {..} tx btcBlockHeight
               , stakeData = stakeData
               , preimage = revealedPreimage
               , unstakingIntentBlockHeight = btcBlockHeight
-              , expectedUnstakingTxid = expectedUnstakingTxidFromSummary summary
+              , expectedUnstakingTxid = unstaking summary
               , signatures = signatures
               }
           output = StakeTransitionOutput {duty = Nothing}

--- a/src/Stake.hs
+++ b/src/Stake.hs
@@ -10,6 +10,7 @@ module Stake
   , processUnstakingPartials
   , processStakeConfirmed
   , processPreimageRevealed
+  , processSlashConfirmed
   , processUnstaking
   , notifyNewBlock
   , hasStaked
@@ -42,6 +43,7 @@ type PartialSig = String -- Placeholder for partial signature (used for MuSig2 s
 type Signature = String -- Placeholder for aggregated signature
 type SchnorrKey = String -- Placeholder for Schnorr public key
 type P2PKey = String -- Placeholder for P2P public key
+type OutPoint = (Txid, U32) -- Placeholder for Bitcoin transaction outpoint (txid and output index)
 
 data StakeGraphSummary = StakeGraphSummary
   { stake :: Txid
@@ -49,6 +51,9 @@ data StakeGraphSummary = StakeGraphSummary
   , unstaking :: Txid
   }
   deriving (Show, Eq, Ord)
+
+inpoints :: Transaction -> NonEmpty OutPoint
+inpoints _ = ("txid_placeholder", 0) :| [] -- Placeholder implementation for input outpoints (head :| tail)
 
 txid :: Transaction -> Txid
 txid _ = "txid_placeholder" -- Placeholder implementation
@@ -65,6 +70,10 @@ stakeGraphSummaryFromStakeData _ =
 -- Numbers are chosen arbitrarily
 unstakingTimelock :: U32
 unstakingTimelock = 3024 -- maximum duration (in Bitcoin blocks) for the withdrawal game
+
+-- Constants
+stakeOutputIndex :: U32
+stakeOutputIndex = 1 -- the output index in the stake transaction that is used as input
 
 -- State
 -- Represents the state of the operator stakes
@@ -108,10 +117,15 @@ data StakeState
       { operatorIdx :: OperatorIdx
       , lastBlockHeight :: BitcoinBlockHeight
       , stakeData :: StakeData
+      , summary :: StakeGraphSummary
       , preimage :: Preimage -- the unstaking preimage revealed by the operator
       , unstakingIntentBlockHeight :: BitcoinBlockHeight -- the block height at which the unstaking intent transaction was confirmed
-      , expectedUnstakingTxid :: Txid -- the expected txid of the unstaking transaction
       , signatures :: Maybe (StakeFunctor Signature) -- signatures may be absent if collection finished too late
+      }
+  | Slashed -- state where the operator's stake has been slashed by another operator
+      { operatorIdx :: OperatorIdx
+      , summary :: StakeGraphSummary
+      , preimage' :: Maybe Preimage -- the preimage revealed if transition occurs from the `PreimageRevealed` state (needed for UnstakingBurn)
       }
   | Unstaked -- state where the unstaking transaction has been confirmed on-chain
       { operatorIdx :: OperatorIdx
@@ -201,6 +215,10 @@ verifyAllPartials
 verifyAllPartials opTable opIdx pubNonces aggNonces partials =
   all (verifyPartialSig opTable opIdx pubNonces aggNonces) (NonEmpty.toList partials)
 
+isSlashTx :: StakeGraphSummary -> Transaction -> Bool
+-- Spends the stake output but is not the unstaking transaction
+isSlashTx summary tx = ((stake summary, stakeOutputIndex) `elem` inpoints tx) && txid tx /= unstaking summary
+
 -- State Transition Functions
 -- Functions to handle state transitions based on events
 -- Declarations
@@ -211,6 +229,7 @@ processUnstakingPartials
   :: StakeState -> OperatorTable -> OperatorIdx -> NonEmpty PartialSig -> (StakeState, StakeTransitionOutput) -- UnstakingNoncesCollected -> UnstakingSigned
 processStakeConfirmed :: StakeState -> Transaction -> (StakeState, StakeTransitionOutput) -- UnstakingSigned -> Confirmed
 processPreimageRevealed :: StakeState -> Transaction -> BitcoinBlockHeight -> (StakeState, StakeTransitionOutput) -- Confirmed -> PreimageRevealed
+processSlashConfirmed :: StakeState -> Transaction -> (StakeState, StakeTransitionOutput) -- (Confirmed | PreimageRevealed) -> Slashed
 processUnstaking :: StakeState -> Transaction -> (StakeState, StakeTransitionOutput) -- PreimageRevealed -> Unstaked
 notifyNewBlock :: StakeState -> BitcoinBlockHeight -> (StakeState, StakeTransitionOutput) -- PreimageRevealed -> PreimageRevealed (with duty to publish unstaking tx)
 
@@ -323,11 +342,9 @@ processPreimageRevealed Confirmed {..} tx btcBlockHeight
             PreimageRevealed
               { operatorIdx = operatorIdx
               , lastBlockHeight = btcBlockHeight
-              , stakeData = stakeData
               , preimage = revealedPreimage
               , unstakingIntentBlockHeight = btcBlockHeight
-              , expectedUnstakingTxid = unstaking summary
-              , signatures = signatures
+              , ..
               }
           output = StakeTransitionOutput {duty = Nothing}
       in  (newState, output)
@@ -335,13 +352,37 @@ processPreimageRevealed PreimageRevealed {} _ _ = error "Duplicate: Preimage has
 processPreimageRevealed Unstaked {} _ _ = error "Rejected: Terminal state"
 processPreimageRevealed state _ _ = error $ "Invalid Event: Invalid state for preimage revelation: " ++ show state
 
+processSlashConfirmed Confirmed {..} tx
+  | isSlashTx summary tx =
+      let newState =
+            Slashed
+              { preimage' = Nothing
+              , ..
+              }
+          output = StakeTransitionOutput {duty = Nothing}
+      in  (newState, output)
+  | otherwise = error "Rejected: Transaction does not match expected slash transaction"
+processSlashConfirmed PreimageRevealed {..} tx
+  | isSlashTx summary tx =
+      let newState =
+            Slashed
+              { preimage' = Just preimage
+              , ..
+              }
+          output = StakeTransitionOutput {duty = Nothing}
+      in  (newState, output)
+  | otherwise = error "Rejected: Transaction does not match expected slash transaction"
+processSlashConfirmed Slashed {} _ = error "Duplicate: Stake has already been slashed"
+processSlashConfirmed Unstaked {} _ = error "Rejected: Terminal state"
+processSlashConfirmed state _ = error $ "Invalid Event: Invalid state for slash confirmation: " ++ show state
+
 processUnstaking PreimageRevealed {..} tx
-  | txid tx == expectedUnstakingTxid =
+  | txid tx == unstaking summary =
       let newState =
             Unstaked
               { operatorIdx = operatorIdx
               , preimage = preimage
-              , unstakingTxid = expectedUnstakingTxid
+              , unstakingTxid = unstaking summary
               }
           output = StakeTransitionOutput {duty = Nothing}
       in  (newState, output)
@@ -358,6 +399,7 @@ notifyNewBlock state@PreimageRevealed {..} btcBlockHeight
           output = StakeTransitionOutput {duty = Just PublishUnstakingTx {unstakingTx}}
       in  (state {lastBlockHeight = btcBlockHeight}, output)
   | otherwise = (PreimageRevealed {lastBlockHeight = btcBlockHeight, ..}, emptyOutput)
+notifyNewBlock Slashed {} _ = error "Rejected: terminal state"
 notifyNewBlock Unstaked {} _ = error "Rejected: terminal state"
 notifyNewBlock state btcBlockHeight = (state {lastBlockHeight = btcBlockHeight}, emptyOutput)
 


### PR DESCRIPTION
 This PR updates the Stake SM to also track the slash transaction so that the Stake SM can own the stake lifecycle more fully. This includes adding a new `Slashed` state and a new `processSlashConfirmed` STF.

 Auxiliary change:

- The `StakeGraphSummary` is a more proper type now.
- Placeholder helpers to extract invidivual Txid's have been replaced with getters.

AI was used for autocompletion.

Stake SM diagram will be updated after these changes are approved.