### PR TITLE
fix(gsm): handle payout connector spends properly

### DIFF
--- a/src/Graph.hs
+++ b/src/Graph.hs
@@ -327,6 +327,7 @@ data GraphState
       , depositOutPoint :: OutPoint
       , blockHeight :: BitcoinBlockHeight
       , contestBlockHeight :: BitcoinBlockHeight
+      , claimTxid :: Txid -- the txid of the claim transaction (required in order to check if the payout connector is spent)
       , expectedPayoutTxid :: Txid -- the txid of the expected contested payout transaction (full summary can be discarded)
       , possibleSlashTxid :: Txid -- the txid of the possible slash transaction (this can happen if the operator is not functional/live)
       }
@@ -494,7 +495,7 @@ processCounterProofAckd :: GraphState -> Transaction -> (GraphState, GraphTransi
 processCounterProofNackd :: GraphState -> Transaction -> (GraphState, GraphTransitionOutput) -- CounterProofPosted -> AllNackd
 processSlash :: GraphState -> Transaction -> (GraphState, GraphTransitionOutput) -- BridgeProofTimedout/Acked -> Slashed
 processPayout :: GraphState -> Transaction -> (GraphState, GraphTransitionOutput) -- -> AllNackd/BridgeProofPosted/Claimed -> Withdrawn
-processPayoutConnectorSpent :: GraphState -> Transaction -> (GraphState, GraphTransitionOutput) -- [`Claimed`..`CounterProofPosted`] -> Aborted
+processPayoutConnectorSpent :: GraphState -> Transaction -> (GraphState, GraphTransitionOutput) -- [`Claimed`..`CounterProofPosted`] -> (Aborted | .payoutConnectorSpent = Just ..)
 notifyNewBlock :: GraphState -> OperatorTable -> BitcoinBlockHeight -> (GraphState, GraphTransitionOutput) -- \* -> *TimedOut
 -- Definitions
 processGraphData Created {..} opTable graphData =
@@ -953,6 +954,7 @@ processCounterProofNackd CounterProofPosted {..} tx =
                   ( AllNackd
                       { expectedPayoutTxid = contestedPayout graphSummary
                       , possibleSlashTxid = slash graphSummary
+                      , claimTxid = claim graphSummary
                       , ..
                       }
                   , emptyOutput
@@ -1029,17 +1031,32 @@ processPayout state _ = error $ "Invalid state for payout: " ++ show state
 -- technically, this can only happen from the `Claimed` state
 -- but if the payout connector has been spent, it means we've already reached the `Claimed` state
 -- so this allows us to have a simpler definition for this STF
--- also note that this should be checked _after_ the payout checks
--- since payouts also spend this connector
 processPayoutConnectorSpent state tx
-  | any (`elem` inpoints tx) (getPayoutConnectorOutPoint state) =
-      ( Aborted
-          { reason = PayoutConnectorSpent {spendingTxid = txid tx}
-          , depositIdx = state.depositIdx
-          , operatorIdx = state.operatorIdx
-          }
-      , emptyOutput
-      )
+  | any (`elem` inpoints tx) (getPayoutConnectorOutPoint state) && not (isPayoutTx state tx) =
+      let spenderTxid = txid tx
+          isStakeSpent = isJust (stakeSpent state)
+          newState = case state of
+            Claimed {..} ->
+              if isStakeSpent
+                then Aborted {reason = PayoutConnectorSpent {spendingTxid = spenderTxid}, ..}
+                else state {payoutConnectorSpent = Just spenderTxid}
+            Contested {..} ->
+              if isStakeSpent
+                then Aborted {reason = PayoutConnectorSpent {spendingTxid = spenderTxid}, ..}
+                else state {payoutConnectorSpent = Just spenderTxid}
+            BridgeProofPosted {..} ->
+              if isStakeSpent
+                then Aborted {reason = PayoutConnectorSpent {spendingTxid = spenderTxid}, ..}
+                else state {payoutConnectorSpent = Just spenderTxid}
+            CounterProofPosted {..} ->
+              if isStakeSpent
+                then Aborted {reason = PayoutConnectorSpent {spendingTxid = spenderTxid}, ..}
+                else state {payoutConnectorSpent = Just spenderTxid}
+            AllNackd {..} -> Aborted {reason = PayoutConnectorSpent {spendingTxid = spenderTxid}, ..}
+            BridgeProofTimedout {} -> error "Rejected payout connector spend since in BridgeProofTimedout since payout is already impossible"
+            Acked {} -> error "Rejected payout connector spend since in Ackd since payout is already impossible"
+            _ -> error "Payout connector can only be spent in Claimed, Contested, BridgeProofPosted or CounterProofPosted states"
+      in  (newState, emptyOutput)
   | otherwise = error "Payout connector not spent in the provided transaction"
 
 mkSlashOutput :: GraphState -> GraphTransitionOutput
@@ -1178,7 +1195,7 @@ getPayoutConnectorOutPoint state =
         BridgeProofTimedout {..} -> Just claimTxid
         Acked {..} -> Just claimTxid
         CounterProofPosted {..} -> Just graphSummary.claim
-        AllNackd {} -> Nothing
+        AllNackd {..} -> Just claimTxid
         Withdrawn {} -> Nothing
         Slashed {} -> Nothing
         Aborted {} -> Nothing
@@ -1187,6 +1204,18 @@ getPayoutConnectorOutPoint state =
           then Just (fromJust claimTxid', payoutConnectorIdx)
           else Nothing
   in  outpoint
+
+isPayoutTx :: GraphState -> Transaction -> Bool
+isPayoutTx state tx =
+  let txid' = txid tx
+  in  case state of
+        -- only handle states where payout is even possible
+        Claimed {..} -> txid' == uncontestedPayout graphSummary || txid tx == contestedPayout graphSummary
+        Contested {..} -> txid' == contestedPayout graphSummary
+        BridgeProofPosted {..} -> txid' == contestedPayout graphSummary
+        CounterProofPosted {..} -> txid' == contestedPayout graphSummary
+        AllNackd {..} -> txid' == expectedPayoutTxid
+        _ -> False
 
 lastProcessedBlock :: GraphState -> Maybe BitcoinBlockHeight
 lastProcessedBlock state = case state of

--- a/src/Graph.hs
+++ b/src/Graph.hs
@@ -399,6 +399,7 @@ data GraphDuty -- Tasks to be completed post state transition
       , graphInpoints :: NonEmpty OutPoint -- the inpoints of the graph (used to retrieve s2 musig2 session per input being signed)
       , graphTweaks :: NonEmpty Tweak -- the tweak required for taproot spend per input being signed
       , claimTxid :: Txid -- the txid of the claim transaction (since the claim transaction is under complete control of an operator, make sure this transaction does not exist on chain before signing off)
+      , stakeOutPoint :: OutPoint -- the outpoint of the stake transaction that this graph is associated with (used to make sure the stake has not been spent before signing off on the graph)
       }
   | PublishClaim
       { signedClaimTx :: Transaction -- the claim transaction to be published
@@ -590,6 +591,7 @@ processNonces AdaptorsVerified {..} execConfig (opIdx, receivedNonces) =
                       , graphInpoints = NonEmpty.fromList [("inpoints placeholder", 0)] -- Placeholder for graph inpoints (needs to be extracted from graph)
                       , graphTweaks = NonEmpty.fromList [Nothing] -- Placeholder for graph tweaks (needs to be extracted from graph)
                       , claimTxid = claim graphSummary
+                      , stakeOutPoint = stakeOutPoint
                       }
               }
           )
@@ -617,7 +619,10 @@ processPartials NoncesCollected {..} execConfig (opIdx, receivedPartials) =
           else error $ "Duplicate partial signatures received from operator: " ++ show opIdx
       expectedOperatorCount = opCardinality execConfig
       claimTxid = claim graphSummary
-  in  if Map.size newPartials == expectedOperatorCount
+  in  -- even if the stake has been spent, collecting partials is still fine
+      -- so that if there is a race between partial generation and stake being spent,
+      -- the state machine can still make progress.
+      if Map.size newPartials == expectedOperatorCount
         then
           ( GraphSigned
               { maybeAggNonces = Just aggNonces
@@ -985,7 +990,7 @@ processCounterProofNackd AllNackd {} _ = error "All counterproofs already NACK'd
 processCounterProofNackd state _ = error $ "Invalid state for counterproof NACK: " ++ show state
 
 processStakeSpent state tx
-  | stakeOutPoint state `elem` inpoints tx =
+  | state.stakeOutPoint `elem` inpoints tx =
       let spenderTxid = txid tx
           isPayoutConnectorSpent = isJust (payoutConnectorSpent state)
           newState =
@@ -1411,6 +1416,7 @@ processNagReceivedGraphPartials state = case state of
         , graphInpoints = NonEmpty.fromList [("inpoints placeholder", 0)]
         , graphTweaks = NonEmpty.fromList [Nothing]
         , claimTxid = claim graphSummary
+        , stakeOutPoint = stakeOutPoint
         }
   GraphSigned {..} ->
     case maybeAggNonces of
@@ -1424,6 +1430,7 @@ processNagReceivedGraphPartials state = case state of
             , graphInpoints = NonEmpty.fromList [("inpoints placeholder", 0)]
             , graphTweaks = NonEmpty.fromList [Nothing]
             , claimTxid = claim graphSummary
+            , stakeOutPoint = stakeOutPoint
             }
       Nothing -> Set.empty -- reverted from Assigned, don't respond to nag
   _ -> Set.empty

--- a/src/Graph.hs
+++ b/src/Graph.hs
@@ -24,9 +24,9 @@ module Graph
   , processCounterProof
   , processCounterProofAckd
   , processCounterProofNackd
-  , processSlash
   , processPayout
   , processPayoutConnectorSpent
+  , processStakeSpent
   , notifyNewBlock
   , lastProcessedBlock
   , processNagTick
@@ -507,7 +507,7 @@ processCounterProof
   :: GraphState -> OperatorTable -> Transaction -> BitcoinBlockHeight -> (GraphState, GraphTransitionOutput) -- BridgeProofPosted/CounterProofPosted -> CounterProofPosted
 processCounterProofAckd :: GraphState -> Transaction -> (GraphState, GraphTransitionOutput) -- CounterProofPosted -> Acked
 processCounterProofNackd :: GraphState -> Transaction -> (GraphState, GraphTransitionOutput) -- CounterProofPosted -> AllNackd
-processSlash :: GraphState -> Transaction -> (GraphState, GraphTransitionOutput) -- BridgeProofTimedout/Acked -> Slashed
+processStakeSpent :: GraphState -> Transaction -> (GraphState, GraphTransitionOutput) -- [`GraphSigned`..] -> [Aborted | Slashed | .stakeSpent = Just ..]
 processPayout :: GraphState -> Transaction -> (GraphState, GraphTransitionOutput) -- -> AllNackd/BridgeProofPosted/Claimed -> Withdrawn
 processPayoutConnectorSpent :: GraphState -> Transaction -> (GraphState, GraphTransitionOutput) -- [`Claimed`..`CounterProofPosted`] -> (Aborted | .payoutConnectorSpent = Just ..)
 notifyNewBlock :: GraphState -> OperatorTable -> BitcoinBlockHeight -> (GraphState, GraphTransitionOutput) -- \* -> *TimedOut
@@ -984,38 +984,62 @@ processCounterProofNackd CounterProofPosted {..} tx =
 processCounterProofNackd AllNackd {} _ = error "All counterproofs already NACK'd"
 processCounterProofNackd state _ = error $ "Invalid state for counterproof NACK: " ++ show state
 
-mkSlashed :: DepositIdx -> OperatorIdx -> Txid -> (GraphState, GraphTransitionOutput)
-mkSlashed depositIdx operatorIdx slashTxid =
-  ( Slashed
-      { slashTxid = slashTxid
-      , ..
-      }
-  , GraphTransitionOutput
-      { signal = Just (OperatorSlashed operatorIdx) -- sent to the Operator State Machine
-      , duty = Nothing
-      }
-  )
-
-processSlash Contested {..} tx
-  | txid tx == slash graphSummary = mkSlashed depositIdx operatorIdx (txid tx)
-  | otherwise = error "Invalid slash transaction"
-processSlash BridgeProofPosted {..} tx
-  | txid tx == slash graphSummary = mkSlashed depositIdx operatorIdx (txid tx)
-  | otherwise = error "Invalid slash transaction"
-processSlash CounterProofPosted {..} tx
-  | txid tx == slash graphSummary = mkSlashed depositIdx operatorIdx (txid tx)
-  | otherwise = error "Invalid slash transaction"
-processSlash BridgeProofTimedout {..} tx
-  | txid tx == expectedSlashTxid = mkSlashed depositIdx operatorIdx (txid tx)
-  | otherwise = error "Invalid slash transaction"
-processSlash Acked {..} tx
-  | txid tx == expectedSlashTxid = mkSlashed depositIdx operatorIdx (txid tx)
-  | otherwise = error "Invalid slash transaction"
-processSlash AllNackd {..} tx
-  | txid tx == possibleSlashTxid = mkSlashed depositIdx operatorIdx (txid tx)
-  | otherwise = error "Invalid slash transaction"
-processSlash Slashed {} _ = error "Operator already slashed"
-processSlash state _ = error $ "Invalid state for slash: " ++ show state
+processStakeSpent state tx
+  | stakeOutPoint state `elem` inpoints tx =
+      let spenderTxid = txid tx
+          isPayoutConnectorSpent = isJust (payoutConnectorSpent state)
+          newState =
+            if getSlashTxid state == Just spenderTxid
+              then
+                -- if the stake is spent by the slash transaction, we can directly transition to `Slashed` without going through the intermediate states
+                -- this is only possible from certain states but for simplicity, we can just transition to this state directly,
+                -- and depend on bitcoin consensus to make sure the transaction graph is being followed.
+                Slashed {slashTxid = spenderTxid, depositIdx = state.depositIdx, operatorIdx = state.operatorIdx}
+              -- now for cases where stake is spent by a transaction other than this graph's slash transaction.
+              else case state of
+                NoncesCollected {..} -> NoncesCollected {stakeSpent = Just spenderTxid, ..}
+                GraphSigned {..} -> GraphSigned {stakeSpent = Just spenderTxid, ..}
+                Assigned {..} -> Assigned {stakeSpent = Just spenderTxid, ..}
+                Fulfilled {..} -> Fulfilled {stakeSpent = Just spenderTxid, ..}
+                Claimed {..} ->
+                  if isPayoutConnectorSpent
+                    then
+                      -- can't get payout and can't get slashed now, only thing to do is abort
+                      Aborted {reason = StakeSpent {spendingTxid = spenderTxid}, ..}
+                    else Claimed {stakeSpent = Just spenderTxid, ..}
+                Contested {..} ->
+                  if isPayoutConnectorSpent
+                    then
+                      -- can't get payout and can't get slashed now, only thing to do is abort
+                      Aborted {reason = StakeSpent {spendingTxid = spenderTxid}, ..}
+                    else
+                      Contested {stakeSpent = Just spenderTxid, ..}
+                BridgeProofPosted {..} ->
+                  if isPayoutConnectorSpent
+                    then
+                      -- can't get payout and can't get slashed now, only thing to do is abort
+                      Aborted {reason = StakeSpent {spendingTxid = spenderTxid}, ..}
+                    else
+                      BridgeProofPosted {stakeSpent = Just spenderTxid, ..}
+                -- the only path from this state is slashing but if that has been spent, nothing more can be done so we abort
+                BridgeProofTimedout {..} -> Aborted {reason = StakeSpent {spendingTxid = spenderTxid}, ..}
+                CounterProofPosted {..} ->
+                  if isPayoutConnectorSpent
+                    then
+                      -- can't get payout and can't get slashed now, only thing to do is abort
+                      Aborted {reason = StakeSpent {spendingTxid = spenderTxid}, ..}
+                    else
+                      CounterProofPosted {stakeSpent = Just spenderTxid, ..}
+                -- the only possible path from here was slashed, so if the stake has already been spent, abort
+                Acked {..} ->
+                  Aborted {reason = StakeSpent {spendingTxid = spenderTxid}, ..}
+                _ ->
+                  error
+                    "Stake spends need only be checked in GraphSigned, Assigned, Fulfilled, Contested, BridgeProofPosted, BridgeProofTimedout, CounterProofPosted and Acked states"
+      in  ( newState
+          , emptyOutput
+          )
+  | otherwise = error "Stake not spent in the provided transaction"
 
 mkWithdrawn :: DepositIdx -> OperatorIdx -> Transaction -> (GraphState, GraphTransitionOutput)
 mkWithdrawn depositIdx operatorIdx payoutTx =
@@ -1066,6 +1090,7 @@ processPayoutConnectorSpent state tx
               if isStakeSpent
                 then Aborted {reason = PayoutConnectorSpent {spendingTxid = spenderTxid}, ..}
                 else state {payoutConnectorSpent = Just spenderTxid}
+            -- supposed to get the payout but if that connector is already burnt, the only thing to do is abort
             AllNackd {..} -> Aborted {reason = PayoutConnectorSpent {spendingTxid = spenderTxid}, ..}
             BridgeProofTimedout {} -> error "Rejected payout connector spend since in BridgeProofTimedout since payout is already impossible"
             Acked {} -> error "Rejected payout connector spend since in Ackd since payout is already impossible"
@@ -1230,6 +1255,18 @@ isPayoutTx state tx =
         CounterProofPosted {..} -> txid' == contestedPayout graphSummary
         AllNackd {..} -> txid' == expectedPayoutTxid
         _ -> False
+
+getSlashTxid :: GraphState -> Maybe Txid
+getSlashTxid state = case state of
+  -- only handle states from where slashing is possible
+  Claimed {..} -> Just $ slash graphSummary
+  Contested {..} -> Just $ slash graphSummary
+  BridgeProofPosted {..} -> Just $ slash graphSummary
+  BridgeProofTimedout {..} -> Just expectedSlashTxid
+  CounterProofPosted {..} -> Just $ slash graphSummary
+  Acked {..} -> Just expectedSlashTxid
+  AllNackd {..} -> Just possibleSlashTxid
+  _ -> Nothing
 
 lastProcessedBlock :: GraphState -> Maybe BitcoinBlockHeight
 lastProcessedBlock state = case state of

--- a/src/Graph.hs
+++ b/src/Graph.hs
@@ -999,15 +999,27 @@ processCounterProofNackd CounterProofPosted {..} tx =
           let nacks = Map.insert nackdIdx (txid tx) counterProofNacks
               expectedNacks = Map.size (counterproofs graphSummary)
           in  if Map.size nacks == expectedNacks
-                then
-                  ( AllNackd
-                      { expectedPayoutTxid = contestedPayout graphSummary
-                      , possibleSlashTxid = slash graphSummary
-                      , claimTxid = claim graphSummary
-                      , ..
-                      }
-                  , emptyOutput
-                  )
+                then case payoutConnectorSpent of
+                  -- The only path forward from `AllNackd` is the contested payout, which consumes
+                  -- the payout connector. If the connector is already gone, abort directly instead
+                  -- of entering a state with no exit (`AllNackd` does not carry the
+                  -- `payoutConnectorSpent` field, so the prior record would otherwise be lost).
+                  Just spenderTxid ->
+                    ( Aborted
+                        { reason = PayoutConnectorSpent {spendingTxid = spenderTxid}
+                        , ..
+                        }
+                    , emptyOutput
+                    )
+                  Nothing ->
+                    ( AllNackd
+                        { expectedPayoutTxid = contestedPayout graphSummary
+                        , possibleSlashTxid = slash graphSummary
+                        , claimTxid = claim graphSummary
+                        , ..
+                        }
+                    , emptyOutput
+                    )
                 else
                   ( CounterProofPosted
                       { counterProofNacks = nacks

--- a/src/Graph.hs
+++ b/src/Graph.hs
@@ -127,6 +127,9 @@ data AbortReason
       { spendingTxid :: Txid -- the txid of the transaction that spent the payout connector
       }
   | DepositSpent
+  | StakeSpent
+      { spendingTxid :: Txid -- the txid of the transaction that spent the stake (via another GraphSM instance)
+      }
   deriving (Show, Eq, Ord)
 
 newtype OperatorTable = OperatorTable
@@ -199,6 +202,7 @@ data GraphState
       , nonces :: Map OperatorIdx (NonEmpty Nonce)
       , aggNonces :: NonEmpty AggNonce -- aggregated nonces (packed/flattened representation)
       , partials :: Map OperatorIdx (NonEmpty PartialSignature) -- partials from each operator
+      , stakeSpent :: Maybe Txid -- the txid of the transaction that spent the operator's stake (if present; used to determine whether the graph should be aborted or slashed)
       }
   | GraphSigned
       { -- Represents a state where all required aggregate signatures for this pegout graph have been collected
@@ -208,6 +212,7 @@ data GraphState
       , blockHeight :: BitcoinBlockHeight
       , graphData :: GraphData
       , graphSummary :: GraphSummary
+      , stakeSpent :: Maybe Txid
       , maybeAggNonces :: Maybe (NonEmpty AggNonce) -- needed to respond to nag for graph partial signature; Nothing if reverted from Assigned
       , signatures :: NonEmpty Signature -- final signatures per operator graph (packed/flattened representation)
       }
@@ -220,6 +225,7 @@ data GraphState
       , graphData :: GraphData
       , graphSummary :: GraphSummary
       , signatures :: NonEmpty Signature
+      , stakeSpent :: Maybe Txid
       , assignee :: OperatorIdx -- the operator assigned to fulfill the withdrawal
       , deadline :: BitcoinBlockHeight -- the block height by which the withdrawal must be fulfilled
       , recipientDesc :: BtcDescriptor -- the BTC descriptor for the recipient
@@ -232,6 +238,7 @@ data GraphState
       , blockHeight :: BitcoinBlockHeight
       , graphData :: GraphData
       , graphSummary :: GraphSummary
+      , stakeSpent :: Maybe Txid
       , coopPayoutFailed :: Bool -- whether cooperative payout has failed and unilateral claim path is activated
       , assignee :: OperatorIdx -- the operator assigned to fulfill the withdrawal
       , fulfillmentTxid :: Txid -- the txid of the fulfillment transaction submitted on chain
@@ -245,9 +252,11 @@ data GraphState
       , blockHeight :: BitcoinBlockHeight
       , graphData :: GraphData
       , graphSummary :: GraphSummary
+      , stakeSpent :: Maybe Txid
       , fulfillmentTxid' :: Maybe Txid -- the txid of the fulfillment transaction submitted on chain (if present; could be absent for faulty claims)
       , fulfillmentBlockHeight' :: Maybe BitcoinBlockHeight -- the block height at which the fulfillment transaction was confirmed (if present; could be absent for faulty claims)
       , claimBlockHeight :: BitcoinBlockHeight -- the block height at which the claim transaction was confirmed (required for timeout calculations)
+      , payoutConnectorSpent :: Maybe Txid -- the txid of the transaction that spent the payout connector (if present; used to determine whether the graph should be aborted)
       }
   | Contested
       { -- Represents a state where the contest transaction has been posted on chain
@@ -257,6 +266,8 @@ data GraphState
       , blockHeight :: BitcoinBlockHeight
       , graphData :: GraphData
       , graphSummary :: GraphSummary
+      , stakeSpent :: Maybe Txid
+      , payoutConnectorSpent :: Maybe Txid
       , fulfillmentTxid' :: Maybe Txid
       , fulfillmentBlockHeight' :: Maybe BitcoinBlockHeight
       , contestBlockHeight :: BitcoinBlockHeight -- the block height at which the contest transaction was confirmed
@@ -269,6 +280,8 @@ data GraphState
       , blockHeight :: BitcoinBlockHeight
       , graphData :: GraphData
       , graphSummary :: GraphSummary
+      , stakeSpent :: Maybe Txid
+      , payoutConnectorSpent :: Maybe Txid
       , fulfillmentTxid' :: Maybe Txid -- needed to know whether a claim is valid in the subsequent states where proof may not be present.
       , contestBlockHeight :: BitcoinBlockHeight -- needed in case the operator needs to be slashed after contested payout timeout
       , bridgeProofTxid :: Txid -- the txid of the bridge proof transaction submitted on chain
@@ -277,6 +290,8 @@ data GraphState
       }
   | BridgeProofTimedout
       { -- Represents a state where the bridge proof timeout transaction has been posted on chain
+        -- does not need to track stake being spent because once that happens, we'll just abort the graph (as payout is not possible from here)
+        -- does not need to track the payout connector being spent either for the same reason
         depositIdx :: DepositIdx
       , operatorIdx :: OperatorIdx
       , depositOutPoint :: OutPoint
@@ -294,6 +309,8 @@ data GraphState
       , blockHeight :: BitcoinBlockHeight
       , graphData :: GraphData
       , graphSummary :: GraphSummary
+      , stakeSpent :: Maybe Txid
+      , payoutConnectorSpent :: Maybe Txid
       , contestBlockHeight :: BitcoinBlockHeight
       , fulfillmentTxid' :: Maybe Txid -- needed to know whether a claim is valid in the absence of a bridge proof.
       , refutedProof :: Maybe Proof -- the proof (data) being refuted
@@ -303,6 +320,8 @@ data GraphState
       }
   | AllNackd
       { -- Represents a state where all possible counterproof transactions have been NACK'd on chain
+        -- no need for a `stakeSpent` field as payout might still be possible at this point.
+        -- no need for a `payoutConnectorSpent` field as we'll just move to abort the graph if that happens (as payout is not possible from there)
         depositIdx :: DepositIdx
       , operatorIdx :: OperatorIdx
       , depositOutPoint :: OutPoint
@@ -318,6 +337,7 @@ data GraphState
       , depositOutPoint :: OutPoint
       , blockHeight :: BitcoinBlockHeight
       , contestBlockHeight :: BitcoinBlockHeight
+      , stakeSpent :: Maybe Txid -- no need for payoutConnectorSpent here because if a counterproof is ACKd, then the payout is impossible regardless of whether the payout connector is spent or not
       , expectedSlashTxid :: Txid -- the txid of the expected slash transaction (full summary can be discarded)
       , signedSlashTx :: Transaction -- signed slash transaction to publish if payout window elapses
       , claimTxid :: Txid -- the txid of the claim transaction (required in order to check if the payout connector is spent)
@@ -540,6 +560,7 @@ processNonces AdaptorsVerified {..} execConfig (opIdx, receivedNonces) =
               { nonces = newNonces
               , aggNonces = NonEmpty.fromList ["agg_nonce_placeholder"] -- Placeholder for agg nonces
               , partials = mempty -- Placeholder for partial signatures collection
+              , stakeSpent = Nothing
               , ..
               }
           , GraphTransitionOutput
@@ -685,6 +706,7 @@ processClaim Fulfilled {..} tx claimBlockHeight
       ( Claimed
           { fulfillmentTxid' = Just fulfillmentTxid
           , fulfillmentBlockHeight' = Just fulfillmentBlockHeight
+          , payoutConnectorSpent = Nothing
           , ..
           }
       , emptyOutput
@@ -697,6 +719,7 @@ processClaim Assigned {..} tx claimBlockHeight
       ( Claimed
           { fulfillmentTxid' = Nothing
           , fulfillmentBlockHeight' = Nothing
+          , payoutConnectorSpent = Nothing
           , ..
           }
       , GraphTransitionOutput
@@ -710,6 +733,7 @@ processClaim GraphSigned {..} tx claimBlockHeight
       ( Claimed
           { fulfillmentTxid' = Nothing
           , fulfillmentBlockHeight' = Nothing
+          , payoutConnectorSpent = Nothing
           , ..
           }
       , GraphTransitionOutput

--- a/src/Graph.hs
+++ b/src/Graph.hs
@@ -130,6 +130,11 @@ data AbortReason
   | StakeSpent
       { spendingTxid :: Txid -- the txid of the transaction that spent the stake (via another GraphSM instance)
       }
+  | -- both the payout connector and the stake outpoint have been consumed; preserves both txids for forensics
+    Both
+      { payoutConnectorSpendingTxid :: Txid -- the txid of the transaction that spent the payout connector
+      , stakeSpendingTxid :: Txid -- the txid of the transaction that spent the stake
+      }
   deriving (Show, Eq, Ord)
 
 newtype OperatorTable = OperatorTable
@@ -1035,20 +1040,41 @@ processStakeSpent state tx
                   if isPayoutConnectorSpent
                     then
                       -- can't get payout and can't get slashed now, only thing to do is abort
-                      Aborted {reason = StakeSpent {spendingTxid = spenderTxid}, ..}
+                      Aborted
+                        { reason =
+                            Both
+                              { payoutConnectorSpendingTxid = fromJust payoutConnectorSpent
+                              , stakeSpendingTxid = spenderTxid
+                              }
+                        , ..
+                        }
                     else Claimed {stakeSpent = Just spenderTxid, ..}
                 Contested {..} ->
                   if isPayoutConnectorSpent
                     then
                       -- can't get payout and can't get slashed now, only thing to do is abort
-                      Aborted {reason = StakeSpent {spendingTxid = spenderTxid}, ..}
+                      Aborted
+                        { reason =
+                            Both
+                              { payoutConnectorSpendingTxid = fromJust payoutConnectorSpent
+                              , stakeSpendingTxid = spenderTxid
+                              }
+                        , ..
+                        }
                     else
                       Contested {stakeSpent = Just spenderTxid, ..}
                 BridgeProofPosted {..} ->
                   if isPayoutConnectorSpent
                     then
                       -- can't get payout and can't get slashed now, only thing to do is abort
-                      Aborted {reason = StakeSpent {spendingTxid = spenderTxid}, ..}
+                      Aborted
+                        { reason =
+                            Both
+                              { payoutConnectorSpendingTxid = fromJust payoutConnectorSpent
+                              , stakeSpendingTxid = spenderTxid
+                              }
+                        , ..
+                        }
                     else
                       BridgeProofPosted {stakeSpent = Just spenderTxid, ..}
                 -- the only path from this state is slashing but if that has been spent, nothing more can be done so we abort
@@ -1057,7 +1083,14 @@ processStakeSpent state tx
                   if isPayoutConnectorSpent
                     then
                       -- can't get payout and can't get slashed now, only thing to do is abort
-                      Aborted {reason = StakeSpent {spendingTxid = spenderTxid}, ..}
+                      Aborted
+                        { reason =
+                            Both
+                              { payoutConnectorSpendingTxid = fromJust payoutConnectorSpent
+                              , stakeSpendingTxid = spenderTxid
+                              }
+                        , ..
+                        }
                     else
                       CounterProofPosted {stakeSpent = Just spenderTxid, ..}
                 -- the only possible path from here was slashed, so if the stake has already been spent, abort
@@ -1106,19 +1139,51 @@ processPayoutConnectorSpent state tx
           newState = case state of
             Claimed {..} ->
               if isStakeSpent
-                then Aborted {reason = PayoutConnectorSpent {spendingTxid = spenderTxid}, ..}
+                then
+                  Aborted
+                    { reason =
+                        Both
+                          { payoutConnectorSpendingTxid = spenderTxid
+                          , stakeSpendingTxid = fromJust stakeSpent
+                          }
+                    , ..
+                    }
                 else state {payoutConnectorSpent = Just spenderTxid}
             Contested {..} ->
               if isStakeSpent
-                then Aborted {reason = PayoutConnectorSpent {spendingTxid = spenderTxid}, ..}
+                then
+                  Aborted
+                    { reason =
+                        Both
+                          { payoutConnectorSpendingTxid = spenderTxid
+                          , stakeSpendingTxid = fromJust stakeSpent
+                          }
+                    , ..
+                    }
                 else state {payoutConnectorSpent = Just spenderTxid}
             BridgeProofPosted {..} ->
               if isStakeSpent
-                then Aborted {reason = PayoutConnectorSpent {spendingTxid = spenderTxid}, ..}
+                then
+                  Aborted
+                    { reason =
+                        Both
+                          { payoutConnectorSpendingTxid = spenderTxid
+                          , stakeSpendingTxid = fromJust stakeSpent
+                          }
+                    , ..
+                    }
                 else state {payoutConnectorSpent = Just spenderTxid}
             CounterProofPosted {..} ->
               if isStakeSpent
-                then Aborted {reason = PayoutConnectorSpent {spendingTxid = spenderTxid}, ..}
+                then
+                  Aborted
+                    { reason =
+                        Both
+                          { payoutConnectorSpendingTxid = spenderTxid
+                          , stakeSpendingTxid = fromJust stakeSpent
+                          }
+                    , ..
+                    }
                 else state {payoutConnectorSpent = Just spenderTxid}
             -- supposed to get the payout but if that connector is already burnt, the only thing to do is abort
             AllNackd {..} -> Aborted {reason = PayoutConnectorSpent {spendingTxid = spenderTxid}, ..}

--- a/src/Graph.hs
+++ b/src/Graph.hs
@@ -346,13 +346,14 @@ data GraphState
       }
   | Acked
       { -- Represents a state where a counterproof has been ACK'd on chain
+        -- this state does not need `payoutConnectorSpent` since ACK itself prevents payouts
+        -- this state does not need [non-matching] `stakeSpent` because if that happens, we transition directly to `Aborted`
         depositIdx :: DepositIdx
       , operatorIdx :: OperatorIdx
       , depositOutPoint :: OutPoint
       , stakeOutPoint :: OutPoint
       , blockHeight :: BitcoinBlockHeight
       , contestBlockHeight :: BitcoinBlockHeight
-      , stakeSpent :: Maybe Txid -- no need for payoutConnectorSpent here because if a counterproof is ACKd, then the payout is impossible regardless of whether the payout connector is spent or not
       , expectedSlashTxid :: Txid -- the txid of the expected slash transaction (full summary can be discarded)
       , signedSlashTx :: Transaction -- signed slash transaction to publish if payout window elapses
       , claimTxid :: Txid -- the txid of the claim transaction (required in order to check if the payout connector is spent)
@@ -830,7 +831,7 @@ processBridgeProof CounterProofPosted {refutedProof, ..} opTable _ _
 processBridgeProof state _ _ _ = error $ "Invalid state for bridge proof: " ++ show state
 
 processBridgeProofTimeout Contested {..} tx
-  | txid tx == bridgeProofTimeout graphSummary =
+  | txid tx == bridgeProofTimeout graphSummary && isNothing stakeSpent =
       ( BridgeProofTimedout
           { expectedSlashTxid = slash graphSummary
           , signedSlashTx = "slash_tx_placeholder" -- Placeholder for signed slash transaction
@@ -839,14 +840,30 @@ processBridgeProofTimeout Contested {..} tx
           }
       , emptyOutput
       )
+  -- if stake is already spent, then there is nothing more that needs to be done (as neither payout nor slashing is possible)
+  | txid tx == bridgeProofTimeout graphSummary && isJust stakeSpent =
+      ( Aborted
+          { reason = StakeSpent {spendingTxid = fromJust stakeSpent}
+          , ..
+          }
+      , emptyOutput
+      )
   | otherwise = error "Invalid bridge proof timeout transaction"
 processBridgeProofTimeout CounterProofPosted {..} tx
-  | txid tx == bridgeProofTimeout graphSummary && isNothing refutedProof -- proof has to be Nothing for the timeout to be posted but adding check for safety
+  | txid tx == bridgeProofTimeout graphSummary && isNothing stakeSpent && isNothing refutedProof -- proof has to be Nothing for the timeout to be posted but adding check for safety
     =
       ( BridgeProofTimedout
           { expectedSlashTxid = slash graphSummary
           , signedSlashTx = "slash_tx_placeholder" -- Placeholder for signed slash transaction
           , claimTxid = claim graphSummary
+          , ..
+          }
+      , emptyOutput
+      )
+  -- if stake is already spent, then there is nothing more that needs to be done (as neither payout nor slashing is possible)
+  | txid tx == bridgeProofTimeout graphSummary && isJust stakeSpent =
+      ( Aborted
+          { reason = StakeSpent {spendingTxid = fromJust stakeSpent}
           , ..
           }
       , emptyOutput
@@ -949,11 +966,19 @@ processCounterProof CounterProofPosted {..} opTable tx counterproofBlockHeight =
 processCounterProof state _ _ _ = error $ "Invalid state for counterproof: " ++ show state
 
 processCounterProofAckd CounterProofPosted {..} tx
-  | txid tx `elem` Map.elems (counterproofAcks graphSummary) =
+  | txid tx `elem` Map.elems (counterproofAcks graphSummary) && isNothing stakeSpent =
       ( Acked
           { expectedSlashTxid = slash graphSummary
           , signedSlashTx = "slash_tx_placeholder" -- Placeholder for signed slash transaction
           , claimTxid = claim graphSummary
+          , ..
+          }
+      , emptyOutput
+      )
+  -- if stake is already spent, then there is nothing more that needs to be done (as neither payout nor slashing is possible)
+  | txid tx `elem` Map.elems (counterproofAcks graphSummary) && isJust stakeSpent =
+      ( Aborted
+          { reason = StakeSpent {spendingTxid = fromJust stakeSpent}
           , ..
           }
       , emptyOutput

--- a/src/Graph.hs
+++ b/src/Graph.hs
@@ -170,6 +170,7 @@ data GraphState
         depositIdx :: DepositIdx -- the index of the deposit this graph is associated with
       , operatorIdx :: OperatorIdx -- the index of the operator this graph belongs to
       , depositOutPoint :: OutPoint -- the outpoint deposit transaction associated with this contract , outputIndex :: U32 -- the output index within the deposit transaction that is to be used for this pegout (to allow batched deposits)
+      , stakeOutPoint :: OutPoint -- the outpoint of the stake transaction that this graph is associated with
       , blockHeight :: BitcoinBlockHeight -- the height of the most recent block that this state is aware of
       }
   | GraphGenerated
@@ -177,6 +178,7 @@ data GraphState
         depositIdx :: DepositIdx
       , operatorIdx :: OperatorIdx
       , depositOutPoint :: OutPoint
+      , stakeOutPoint :: OutPoint
       , blockHeight :: BitcoinBlockHeight
       , graphData :: GraphData
       , graphSummary :: GraphSummary -- the txids of the generated pegout graph transactions (required for tx filtering)
@@ -186,6 +188,7 @@ data GraphState
         depositIdx :: DepositIdx
       , operatorIdx :: OperatorIdx
       , depositOutPoint :: OutPoint
+      , stakeOutPoint :: OutPoint
       , blockHeight :: BitcoinBlockHeight
       , graphData :: GraphData
       , graphSummary :: GraphSummary
@@ -196,6 +199,7 @@ data GraphState
         depositIdx :: DepositIdx
       , operatorIdx :: OperatorIdx
       , depositOutPoint :: OutPoint
+      , stakeOutPoint :: OutPoint
       , blockHeight :: BitcoinBlockHeight
       , graphData :: GraphData
       , graphSummary :: GraphSummary
@@ -209,6 +213,7 @@ data GraphState
         depositIdx :: DepositIdx
       , operatorIdx :: OperatorIdx
       , depositOutPoint :: OutPoint
+      , stakeOutPoint :: OutPoint
       , blockHeight :: BitcoinBlockHeight
       , graphData :: GraphData
       , graphSummary :: GraphSummary
@@ -221,6 +226,7 @@ data GraphState
         depositIdx :: DepositIdx
       , operatorIdx :: OperatorIdx
       , depositOutPoint :: OutPoint
+      , stakeOutPoint :: OutPoint
       , blockHeight :: BitcoinBlockHeight
       , graphData :: GraphData
       , graphSummary :: GraphSummary
@@ -235,6 +241,7 @@ data GraphState
         depositIdx :: DepositIdx
       , operatorIdx :: OperatorIdx
       , depositOutPoint :: OutPoint
+      , stakeOutPoint :: OutPoint
       , blockHeight :: BitcoinBlockHeight
       , graphData :: GraphData
       , graphSummary :: GraphSummary
@@ -249,6 +256,7 @@ data GraphState
         depositIdx :: DepositIdx
       , operatorIdx :: OperatorIdx
       , depositOutPoint :: OutPoint
+      , stakeOutPoint :: OutPoint
       , blockHeight :: BitcoinBlockHeight
       , graphData :: GraphData
       , graphSummary :: GraphSummary
@@ -263,6 +271,7 @@ data GraphState
         depositIdx :: DepositIdx
       , operatorIdx :: OperatorIdx
       , depositOutPoint :: OutPoint
+      , stakeOutPoint :: OutPoint
       , blockHeight :: BitcoinBlockHeight
       , graphData :: GraphData
       , graphSummary :: GraphSummary
@@ -277,6 +286,7 @@ data GraphState
         depositIdx :: DepositIdx
       , operatorIdx :: OperatorIdx
       , depositOutPoint :: OutPoint
+      , stakeOutPoint :: OutPoint
       , blockHeight :: BitcoinBlockHeight
       , graphData :: GraphData
       , graphSummary :: GraphSummary
@@ -295,6 +305,7 @@ data GraphState
         depositIdx :: DepositIdx
       , operatorIdx :: OperatorIdx
       , depositOutPoint :: OutPoint
+      , stakeOutPoint :: OutPoint
       , blockHeight :: BitcoinBlockHeight
       , contestBlockHeight :: BitcoinBlockHeight
       , expectedSlashTxid :: Txid -- the txid of the expected slash transaction (full summary can be discarded)
@@ -306,6 +317,7 @@ data GraphState
         depositIdx :: DepositIdx
       , operatorIdx :: OperatorIdx
       , depositOutPoint :: OutPoint
+      , stakeOutPoint :: OutPoint
       , blockHeight :: BitcoinBlockHeight
       , graphData :: GraphData
       , graphSummary :: GraphSummary
@@ -325,6 +337,7 @@ data GraphState
         depositIdx :: DepositIdx
       , operatorIdx :: OperatorIdx
       , depositOutPoint :: OutPoint
+      , stakeOutPoint :: OutPoint
       , blockHeight :: BitcoinBlockHeight
       , contestBlockHeight :: BitcoinBlockHeight
       , claimTxid :: Txid -- the txid of the claim transaction (required in order to check if the payout connector is spent)
@@ -336,6 +349,7 @@ data GraphState
         depositIdx :: DepositIdx
       , operatorIdx :: OperatorIdx
       , depositOutPoint :: OutPoint
+      , stakeOutPoint :: OutPoint
       , blockHeight :: BitcoinBlockHeight
       , contestBlockHeight :: BitcoinBlockHeight
       , stakeSpent :: Maybe Txid -- no need for payoutConnectorSpent here because if a counterproof is ACKd, then the payout is impossible regardless of whether the payout connector is spent or not

--- a/src/Graph.hs
+++ b/src/Graph.hs
@@ -629,17 +629,26 @@ processPartials NoncesCollected {..} execConfig (opIdx, receivedPartials) =
       -- so that if there is a race between partial generation and stake being spent,
       -- the state machine can still make progress.
       if Map.size newPartials == expectedOperatorCount
-        then
-          ( GraphSigned
-              { maybeAggNonces = Just aggNonces
-              , signatures = NonEmpty.fromList ["signature_placeholder"] -- Placeholder for signatures
-              , ..
-              }
-          , GraphTransitionOutput
-              { signal = Just (GraphAvailable claimTxid operatorIdx)
-              , duty = Nothing
-              }
-          )
+        then case stakeSpent of
+          Just _ ->
+            ( GraphSigned
+                { maybeAggNonces = Just aggNonces
+                , signatures = NonEmpty.fromList ["signature_placeholder"] -- Placeholder for signatures
+                , ..
+                }
+            , emptyOutput
+            )
+          Nothing ->
+            ( GraphSigned
+                { maybeAggNonces = Just aggNonces
+                , signatures = NonEmpty.fromList ["signature_placeholder"] -- Placeholder for signatures
+                , ..
+                }
+            , GraphTransitionOutput
+                { signal = Just (GraphAvailable claimTxid operatorIdx)
+                , duty = Nothing
+                }
+            )
         else
           ( NoncesCollected
               { partials = newPartials
@@ -1111,9 +1120,17 @@ processStakeSpent state tx
                 _ ->
                   error
                     "Stake spends need only be checked in GraphSigned, Assigned, Fulfilled, Contested, BridgeProofPosted, BridgeProofTimedout, CounterProofPosted and Acked states"
-      in  ( newState
-          , emptyOutput
-          )
+          -- Emit `OperatorSlashed` whenever this STF terminalizes the graph as
+          -- `Slashed`, so downstream state machines learn that the operator
+          -- has been slashed on-chain.
+          output = case newState of
+            Slashed {} ->
+              GraphTransitionOutput
+                { signal = Just (OperatorSlashed state.operatorIdx)
+                , duty = Nothing
+                }
+            _ -> emptyOutput
+      in  (newState, output)
   | otherwise = error "Stake not spent in the provided transaction"
 
 mkWithdrawn :: DepositIdx -> OperatorIdx -> Transaction -> (GraphState, GraphTransitionOutput)


### PR DESCRIPTION
This PR fixes an issue where a faulty operator can escape punishment by spending the payout connector (and getting the GSM aborted) before they can get slashed. This involves substantial changes to the current transitions.

### Changelog
  - Replace GSM `SlashConfirmed` handling with generalized `StakeSpent`.
  - Add `stakeSpent` tracking from NoncesCollected through states where future claim/burn/slash behavior depends on it.
  - Add `payoutConnectorSpent` tracking for post-claim states where connector spend must not immediately suppress slashing.
  - Keep pre-`Claimed` post-`NoncesCollected` states alive on non-matching `StakeSpent`, preserving the ability to process a later `ClaimConfirmed`.
  - Abort directly in slash-only states when a non-matching stake spend makes slashing impossible.
  - Treat non-payout payout-connector spends separately from valid payout transactions.
  - Add `claimTxid` to `AllNackd` so connector spends can be recognized there and the graph can be aborted (as payouts become impossible).

Copilot was used for autocompletion (and Codex and Claude to review for soundness).