### PR TITLE
fix(gsm): accept payout in CounterproofPosted state

### DIFF
--- a/src/Graph.hs
+++ b/src/Graph.hs
@@ -1152,6 +1152,9 @@ processPayout Contested {..} tx
 processPayout BridgeProofPosted {..} tx
   | txid tx == contestedPayout graphSummary = mkWithdrawn depositIdx operatorIdx tx
   | otherwise = error "Invalid contested payout transaction"
+processPayout CounterProofPosted {..} tx -- this can happen due to liveness fault of watchtowers (such that ACK is not posted)
+  | txid tx == contestedPayout graphSummary = mkWithdrawn depositIdx operatorIdx tx
+  | otherwise = error "Invalid contested payout transaction"
 processPayout AllNackd {..} tx
   | txid tx == expectedPayoutTxid = mkWithdrawn depositIdx operatorIdx tx
   | otherwise = error "Invalid contested payout transaction"


### PR DESCRIPTION
This PR updates the `process_payout` transition so that a contested payout tx is accepted even in the `CounterproofPosted` state. This can happen through liveness fault of the watchtowers where they are unable to post the ACK transaction within the `ack` timelock (or through misconfiguration of the timelock parameters).

The implementation PR has already been merged via https://github.com/alpenlabs/strata-bridge/pull/608.