### PR TITLE
fix(dsm): re-request payout nonce from PayoutDescriptorReceived

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,17 +83,42 @@ jobs:
   fourmolu:
     name: Fourmolu Format Check
     runs-on: ubuntu-latest
+    env:
+      FOURMOLU_VERSION: '0.20.0.0'
+      GHC_VERSION: '9.12.2'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Run Fourmolu
-        uses: haskell-actions/run-fourmolu@v11
+      - name: Setup Haskell
+        uses: haskell-actions/setup@v2
+        id: setup
         with:
-          version: 'latest'
-          pattern: |
-            src/**/*.hs
-            test/**/*.hs
+          ghc-version: ${{ env.GHC_VERSION }}
+          cabal-version: 'latest'
+
+      - name: Cache Fourmolu
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cabal/bin/fourmolu
+            ${{ steps.setup.outputs.cabal-store }}
+          key: fourmolu-${{ runner.os }}-ghc-${{ env.GHC_VERSION }}-${{ env.FOURMOLU_VERSION }}
+
+      - name: Install Fourmolu
+        run: |
+          mkdir -p "$HOME/.cabal/bin"
+          export PATH="$HOME/.cabal/bin:$PATH"
+          if ! command -v fourmolu >/dev/null || ! fourmolu --version | grep -q "fourmolu ${FOURMOLU_VERSION}"; then
+            cabal update
+            cabal install "fourmolu-${FOURMOLU_VERSION}" --install-method=copy --installdir="$HOME/.cabal/bin" --overwrite-policy=always
+          fi
+          echo "$HOME/.cabal/bin" >> "$GITHUB_PATH"
+
+      - name: Run Fourmolu
+        run: |
+          fourmolu --version
+          fourmolu --mode check src/ test/
 
   test:
     name: Test

--- a/src/Deposit.hs
+++ b/src/Deposit.hs
@@ -198,6 +198,7 @@ data DepositDuty
     RequestPayoutNonce
       { depositIdx :: DepositIdx
       , povOperatorIdx :: OperatorIdx -- the index of the point-of-view operator
+      , payoutDescriptor :: Maybe BtcDescriptor -- the output descriptor of the operator for the cooperative payout (if already present)
       }
   | PublishPayoutNonces -- publish the nonce for spending the deposit utxo cooperatively
       { depositIdx :: DepositIdx -- the index of the deposit
@@ -454,7 +455,7 @@ processFulfillment Assigned {..} cfg fulfillmentTx fulfillmentBlockHeight
           povOperatorIdx = povIdx cfg
           duty =
             if assignee == povOperatorIdx
-              then Just RequestPayoutNonce {..}
+              then Just RequestPayoutNonce {payoutDescriptor = Nothing, ..}
               else Nothing
       in  (newState, duty)
   | otherwise =
@@ -698,7 +699,14 @@ processRetryTick state cfg = case state of
     | otherwise -> Set.empty
   Fulfilled {..}
     | assignee == povIdx cfg ->
-        Set.singleton RequestPayoutNonce {depositIdx = depositIdx, povOperatorIdx = povIdx cfg}
+        Set.singleton RequestPayoutNonce {depositIdx = depositIdx, povOperatorIdx = povIdx cfg, payoutDescriptor = Nothing}
+    | otherwise -> Set.empty
+  -- it may be that peers may not have received the payout descriptor yet, so we retry the request for it
+  -- it may also be that peers reject the descriptor if they haven't observed a fulfillment yet
+  PayoutDescriptorReceived {payoutOutputDesc, ..}
+    | assignee == povIdx cfg && Map.size payoutNonces < opCardinality cfg ->
+        Set.singleton
+          RequestPayoutNonce {depositIdx = depositIdx, povOperatorIdx = povIdx cfg, payoutDescriptor = Just payoutOutputDesc}
     | otherwise -> Set.empty
   PayoutNoncesCollected {..}
     | assignee == povIdx cfg && Map.size payoutPartialSignatures == opCardinality cfg - 1 ->


### PR DESCRIPTION
This PR fixes a bug so that the payout descriptor is re-broadcasted (as part of the duty to request nonces) even in the `PayoutDescriptorReceived` state if the node is the assignee, and not all nonces have been collected.

AI was not used.